### PR TITLE
1.1_7: 관리자 페이지 API 연동 완료 -> 꾸미기 必

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-test'
 	compileOnly group: 'org.thymeleaf.extras', name: 'thymeleaf-extras-springsecurity5', version: '3.0.4.RELEASE'
-
+	implementation 'org.springframework.session:spring-session-core'
 
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/DeliveryApiController.java
+++ b/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/DeliveryApiController.java
@@ -1,12 +1,29 @@
 package com.pipe09.OnlineShop.Controller.ApiController;
 
 
+import com.pipe09.OnlineShop.Domain.Delivery.Delivery;
+import com.pipe09.OnlineShop.Dto.DeliveryDto;
+import com.pipe09.OnlineShop.Service.DeliveryService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Slf4j
+@RequiredArgsConstructor
 @RestController
 public class DeliveryApiController {
+    private final DeliveryService service;
+    @GetMapping("/api/v1/delivery/all")
+    public List<DeliveryDto> findall(@RequestParam int offset,@RequestParam int limit){
+        List<Delivery> list=service.findAll(offset,limit);
+        List<DeliveryDto> dtoList=list.stream().map(DeliveryDto::new).collect(Collectors.toList());
+        return dtoList;
+    }
 }
 

--- a/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/ItemApiController.java
+++ b/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/ItemApiController.java
@@ -2,25 +2,26 @@ package com.pipe09.OnlineShop.Controller.ApiController;
 
 
 import com.pipe09.OnlineShop.Domain.Item.Item;
+import com.pipe09.OnlineShop.Dto.ItemDto;
 import com.pipe09.OnlineShop.Dto.M_ItemDto;
 import com.pipe09.OnlineShop.Service.ItemService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-public class MiniItemListController {
+public class ItemApiController {
     private final ItemService service;
 
 
     @GetMapping("/api/v1/m-item")
-    public List<M_ItemDto> getminiItems(){
-        List<Item>items=service.findAll();
+    public List<M_ItemDto> getminiItems(@RequestParam int offset,@RequestParam int limit){
+        List<Item>items=service.findAll(0,100);
         List<M_ItemDto> dtoList=Item.itemtoDto(items);
         log.info("MiniItemList :" + dtoList.toString());
 
@@ -29,8 +30,8 @@ public class MiniItemListController {
     }
 
     @GetMapping("/api/v1/m-item/{DTYPE}")
-    public List<M_ItemDto> getminiItemsbyType(@PathVariable String DTYPE){
-        List<Item>items=service.findAllbyType(DTYPE);
+    public List<M_ItemDto> getminiItemsbyType(@PathVariable String DTYPE,@RequestParam int offset,@RequestParam int limit){
+        List<Item>items=service.findAllbyType(DTYPE,offset,limit);
         List<M_ItemDto>dtoList=Item.itemtoDto(items);
 
         log.info("MiniItemListbyType:"+dtoList.toString());
@@ -44,6 +45,11 @@ public class MiniItemListController {
         List<M_ItemDto>dtoList=Item.itemtoDto(items);
         return dtoList;
     }
-
+    @GetMapping("/api/v1/items/all")
+    public List<ItemDto> getitemall(@RequestParam int offset, @RequestParam int limit){
+        List<Item> list=service.findAll(offset,limit);
+        List<ItemDto> dtoList=list.stream().map(ItemDto::new).collect(Collectors.toList());
+        return dtoList;
+    }
 
 }

--- a/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/ManagerApiController.java
+++ b/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/ManagerApiController.java
@@ -3,8 +3,8 @@ package com.pipe09.OnlineShop.Controller.ApiController;
 
 import com.pipe09.OnlineShop.Domain.Board.Notice;
 import com.pipe09.OnlineShop.Domain.Item.Item;
-import com.pipe09.OnlineShop.Dto.NoticeDto;
-import com.pipe09.OnlineShop.Dto.R_itemDto;
+import com.pipe09.OnlineShop.Domain.Member.Member;
+import com.pipe09.OnlineShop.Dto.*;
 import com.pipe09.OnlineShop.Service.BoardService;
 import com.pipe09.OnlineShop.Service.ItemService;
 import com.pipe09.OnlineShop.Service.MemberService;
@@ -95,6 +95,7 @@ public class ManagerApiController {
 
 
     }
+
 }
 
 

--- a/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/MemberApiController.java
+++ b/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/MemberApiController.java
@@ -1,7 +1,9 @@
 package com.pipe09.OnlineShop.Controller.ApiController;
 
 
+import com.pipe09.OnlineShop.Domain.Member.Member;
 import com.pipe09.OnlineShop.Dto.MemauthDto;
+import com.pipe09.OnlineShop.Dto.MemberManageDto;
 import com.pipe09.OnlineShop.Service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +12,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -33,5 +39,11 @@ public class MemberApiController{
     public ResponseEntity<MemauthDto> status(){
         Authentication auth=SecurityContextHolder.getContext().getAuthentication();
         return new ResponseEntity<MemauthDto>(new MemauthDto(auth.isAuthenticated(),auth.getName(),auth.getAuthorities().toString()), HttpStatus.OK);
+    }
+    @GetMapping("/api/v1/members/all")
+    public List<MemberManageDto> getmemall(@RequestParam int offset, @RequestParam int limit){
+        List<Member> list=memberService.findAll(offset,limit);
+        List<MemberManageDto> dtoList=list.stream().map(MemberManageDto::new).collect(Collectors.toList());
+        return dtoList;
     }
 }

--- a/src/main/java/com/pipe09/OnlineShop/Controller/ManagerController.java
+++ b/src/main/java/com/pipe09/OnlineShop/Controller/ManagerController.java
@@ -31,4 +31,13 @@ public class ManagerController {
     }
     @GetMapping(path="/admin/manage/view-faq")
     public String viewlistfaq(){return "fragments/private/MM_View_FAQ";}
+    @GetMapping(path="/admin/manage/view-members")
+    public String viewlistmem(){return "fragments/private/MM_View_Members";}
+    @GetMapping(path="/admin/manage/view-delivery")
+    public String viewlistdelievery(){ return "fragments/private/MM_View_Delivery";}
+    @GetMapping(path="/admin/manage/view-orders")
+    public String viewlistOrders(){return "fragments/private/MM_View_Orders";}
+    @GetMapping(path="/admin/manage/view-item")
+    public String viewlistItems(){return "fragments/private/MM_View_Item";}
+
 }

--- a/src/main/java/com/pipe09/OnlineShop/Dto/DeliOrdersDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/DeliOrdersDto.java
@@ -1,0 +1,18 @@
+package com.pipe09.OnlineShop.Dto;
+
+import com.pipe09.OnlineShop.Domain.Orders.Orders;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class DeliOrdersDto {
+    Long order_ID;
+    String membername;
+    private Date orderdate;
+    public DeliOrdersDto(Orders o){
+        this.order_ID=o.getOrder_ID();
+        this.membername=o.getMember().getName();
+        this.orderdate=o.getOrderdate();
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/Dto/DeliveryDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/DeliveryDto.java
@@ -1,0 +1,21 @@
+package com.pipe09.OnlineShop.Dto;
+
+import com.pipe09.OnlineShop.Domain.Delivery.Delivery;
+import com.pipe09.OnlineShop.Domain.Delivery.Deliverystatus;
+import com.pipe09.OnlineShop.Domain.Orders.Orders;
+import lombok.Data;
+
+@Data
+public class DeliveryDto {
+    private Long delivery_id;
+    private DeliOrdersDto order;
+    private Deliverystatus status;
+    private String address;
+
+    public DeliveryDto(Delivery delivery){
+        this.delivery_id=delivery.getDelivery_ID();
+        this.order=new DeliOrdersDto(delivery.getOrder());
+        this.status=delivery.getStatus();
+        this.address=delivery.getDelivery_Address();
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/Dto/ItemDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/ItemDto.java
@@ -1,0 +1,37 @@
+package com.pipe09.OnlineShop.Dto;
+
+import com.pipe09.OnlineShop.Domain.Item.Item;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.Column;
+import javax.persistence.Lob;
+
+@Data
+
+public class ItemDto {
+    private Long item_id;
+    private String Name;
+    private int Price;
+    private int StockQuantity;
+    private String Description;
+    ////
+    private int Weight;
+    private String MadeIn;
+    private String ManufacturedCompany;
+    public String imgSrc;
+    private String DTYPE;
+    public ItemDto(Item item){
+        this.item_id=item.getItem_ID();
+        this.Name=item.getName();
+        this.Price=item.getPrice();
+        this.StockQuantity=item.getStockQuantity();
+        this.Description=item.getDescription();
+        this.Weight=item.getWeight();
+        this.MadeIn=item.getMadeIn();
+        this.ManufacturedCompany=item.getManufacturedCompany();
+        this.imgSrc=item.getImgSrc();
+        this.DTYPE=item.getDTYPE();
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/Dto/MemberManageDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/MemberManageDto.java
@@ -1,0 +1,27 @@
+package com.pipe09.OnlineShop.Dto;
+
+import com.pipe09.OnlineShop.Domain.Member.Member;
+import com.pipe09.OnlineShop.Domain.Member.RoleType;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class MemberManageDto {
+    private Long member_id;
+    private RoleType roleType;
+    private String username;
+    private String email;
+    private String name;
+    private String phone_num;
+    private LocalDate enrollddate;
+    public MemberManageDto(Member member){
+        this.member_id=member.getMember_ID();
+        this.roleType=member.getRoleType();
+        this.username=member.getUser_ID();
+        this.email=member.getEmail();
+        this.name=member.getName();
+        this.phone_num=member.getPhone_Num();
+        this.enrollddate=member.getDate();
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/Dto/OrderDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/OrderDto.java
@@ -21,7 +21,7 @@ public class OrderDto {
     private String user_name;
     private List<OrderItemDto> orderItemDto;
     private Delivery delivery;
-    private int Totalprice;
+    private int Totalprice=0;
     @Temporal(TemporalType.DATE)
     private Date orderdate;
     public OrderDto(Orders order){
@@ -32,5 +32,8 @@ public class OrderDto {
         this.delivery=order.getDelivery();
         order.getOrderItems().stream().forEach(item -> item.getItem().getName());
         this.orderItemDto=order.getOrderItems().stream().map(OrderItemDto::new).collect(Collectors.toList());
+        orderItemDto.stream().forEach(orderItemDto1 -> {
+            Totalprice+=orderItemDto1.getTotalprice();
+        });
     }
 }

--- a/src/main/java/com/pipe09/OnlineShop/InitDb.java
+++ b/src/main/java/com/pipe09/OnlineShop/InitDb.java
@@ -13,12 +13,16 @@ import javax.annotation.PostConstruct;
 @RequiredArgsConstructor
 public class InitDb {
     private final InitSerivce initSerivce;
-
+    /*
     @PostConstruct
     public void init(){
         initSerivce.dbInit();
         initSerivce.dbInit2();
+
+
     }
+    */
+
 
 }
 

--- a/src/main/java/com/pipe09/OnlineShop/Repository/DeliveryRepository.java
+++ b/src/main/java/com/pipe09/OnlineShop/Repository/DeliveryRepository.java
@@ -1,0 +1,17 @@
+package com.pipe09.OnlineShop.Repository;
+
+import com.pipe09.OnlineShop.Domain.Delivery.Delivery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryRepository {
+    private final EntityManager em;
+    public List<Delivery> findAll(int offset,int limit){
+        return em.createQuery("select d from Delivery d join fetch d.order o",Delivery.class).setFirstResult(offset).setMaxResults(limit).getResultList();
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/Repository/ItemRepository.java
+++ b/src/main/java/com/pipe09/OnlineShop/Repository/ItemRepository.java
@@ -23,14 +23,14 @@ public class ItemRepository {
     public Item findItem(Long id){
         return em.find(Item.class,id);
     }
-    public List<Item> findAll(){
+    public List<Item> findAll(int offset,int limit){
         String jpql="select i from Item i";
-        return em.createQuery(jpql, Item.class).getResultList();
+        return em.createQuery(jpql, Item.class).setFirstResult(offset).setMaxResults(limit).getResultList();
     }
 
-    public List<Item> findAllbyType(String type){
+    public List<Item> findAllbyType(String type,int offset,int limit){
 
-        return em.createQuery("select i from Item i where i.DTYPE=:type").setParameter("type",type).getResultList();
+        return em.createQuery("select i from Item i where i.DTYPE=:type").setParameter("type",type).setFirstResult(offset).setMaxResults(limit).getResultList();
 
     }
 

--- a/src/main/java/com/pipe09/OnlineShop/Repository/MemberRepository.java
+++ b/src/main/java/com/pipe09/OnlineShop/Repository/MemberRepository.java
@@ -29,8 +29,8 @@ public class MemberRepository {
         return em.createQuery("select m from Member m where m.user_ID=:id", Member.class)
                 .setParameter("id", id).getSingleResult();
     }
-    public List<Member> findAll(){
-        return em.createQuery("select mlist from Member mlist").getResultList();
+    public List<Member> findAll(int offset,int limit){
+        return em.createQuery("select mlist from Member mlist").setFirstResult(offset).setMaxResults(limit).getResultList();
     }
 
 

--- a/src/main/java/com/pipe09/OnlineShop/Service/DeliveryService.java
+++ b/src/main/java/com/pipe09/OnlineShop/Service/DeliveryService.java
@@ -1,0 +1,17 @@
+package com.pipe09.OnlineShop.Service;
+
+import com.pipe09.OnlineShop.Domain.Delivery.Delivery;
+import com.pipe09.OnlineShop.Repository.DeliveryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+    private final DeliveryRepository repository;
+    public List<Delivery> findAll(int offset,int limit){
+        return repository.findAll(offset,limit);
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/Service/ItemService.java
+++ b/src/main/java/com/pipe09/OnlineShop/Service/ItemService.java
@@ -20,7 +20,7 @@ public class ItemService {
     @Transactional
     public Long save(Item item){return itemRepository.save(item); }
 
-    public List<Item> findAll(){ return itemRepository.findAll(); }
+    public List<Item> findAll(int offset,int limit){ return itemRepository.findAll(offset,limit); }
 
     public Item findOne(Long id){
         return itemRepository.findItem(id);
@@ -32,8 +32,8 @@ public class ItemService {
         item.setName(name);
         item.setPrice(price);
     }
-    public List<Item> findAllbyType(String type){
-        return itemRepository.findAllbyType(type);
+    public List<Item> findAllbyType(String type,int offset,int limit){
+        return itemRepository.findAllbyType(type,offset,limit);
     }
     public List<Item> findAllaboutTools(){
         return itemRepository.findAllaboutTools();

--- a/src/main/java/com/pipe09/OnlineShop/Service/MemberService.java
+++ b/src/main/java/com/pipe09/OnlineShop/Service/MemberService.java
@@ -29,8 +29,8 @@ public class MemberService implements UserDetailsService {
     }
 
 
-    public List<Member> findAll(){
-        return memberRepository.findAll();
+    public List<Member> findAll(int offset,int limit){
+        return memberRepository.findAll(offset,limit);
     }
 
     public List<Member> findByname(String name){

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,5 +24,6 @@ multipart.maxRequestSize=100MB
 server.error.include-exception=true
 server.error.include-stacktrace=always
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
-spring.jackson.serialization.fail-on-empty-beans=false 
+spring.jackson.serialization.fail-on-empty-beans=false
+server.servlet.session.timeout=3600
 #logging.level.org.springframework.security=debug

--- a/src/main/resources/static/css/view_delivery.css
+++ b/src/main/resources/static/css/view_delivery.css
@@ -1,0 +1,3 @@
+#delivery_list{
+    list-style: none;
+}

--- a/src/main/resources/static/css/view_item.css
+++ b/src/main/resources/static/css/view_item.css
@@ -1,0 +1,7 @@
+#itemlist{
+    list-style: none;
+}
+#element img{
+    width:40px;
+    height:40px;
+}

--- a/src/main/resources/static/css/view_member.css
+++ b/src/main/resources/static/css/view_member.css
@@ -1,0 +1,3 @@
+#memberlist{
+    list-style: none;
+}

--- a/src/main/resources/static/css/view_order.css
+++ b/src/main/resources/static/css/view_order.css
@@ -1,0 +1,3 @@
+#orderlist{
+    list-style: none;
+}

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -7,7 +7,7 @@ $(document).ready(function(){
 })
 function getItem(){
     Cleaning($("#shoplist"));
-    fetch("./api/v1/m-item",{method:"GET"}).then((response) => response.json()).then(
+    fetch("./api/v1/m-item?offset=0&limit=30",{method:"GET"}).then((response) => response.json()).then(
         (data) => {
             $.each(data, function (idx) {
                 var innerhtml = '<li class="item" id='+data[idx].dtype +'><div id="item_img"><img src=' + data[idx].imgSrc + '></div>' +
@@ -63,6 +63,7 @@ function getTypedItem(dtype){
     else{
         url+=dtype[0];
     }
+    url+="?offset=0&limit=30"
     fetch(url,{method:"GET"}).then((response) => response.json()).then(
         (data) => {
             $.each(data, function (idx, row) {

--- a/src/main/resources/static/js/view_delivery.js
+++ b/src/main/resources/static/js/view_delivery.js
@@ -1,0 +1,19 @@
+$(document).ready(function(){
+    ListSetting()
+})
+function ListSetting(){
+    getDeliverys(0,100);
+}
+async function getDeliverys(offset,limit){
+    const res=await fetch("/api/v1/delivery/all?offset="+offset+"&limit="+limit).then(response => response.json())
+    return ListPrint(res);
+}
+
+function ListPrint(res){
+
+    for(i=0; 0<res.length;i++){
+        var html='<li id="element"><span><a class="delivery_id">'+res[i].delivery_id+'</a><a class="order_id">'+res[i].order.order_ID+'</a><a class="customer_name">'+res[i].order.membername+'</a><a class="orderdate">'+res[i].order.orderdate+'</a><a class="delivery_status">'+res[i].status+'</a><a class="delivery_address">'+res[i].address+'</a></span></li>'
+        $("#delivery_list").append(html);
+    }
+
+}

--- a/src/main/resources/static/js/view_item.js
+++ b/src/main/resources/static/js/view_item.js
@@ -1,0 +1,20 @@
+$(document).ready(function(){
+    ListSetting()
+})
+function ListSetting(){
+    getItems(0,100);
+}
+async function getItems(offset,limit){
+    const res=await fetch("/api/v1/items/all?offset="+offset+"&limit="+limit).then(response => response.json())
+    return ListPrint(res);
+}
+
+function ListPrint(res){
+    var baseurl=window.location
+
+    for(i=0; 0<res.length;i++){
+        var html='<li id="element"><span><a class="item_id">'+res[i].item_id+'</a><img class="itemimg_src" src='+(baseurl .protocol +"//"+baseurl .host+"/"+res[i].imgSrc)+'><a class="itemname">'+res[i].name+'</a><a class="item_desc">'+res[i].description+'</a><a class="item_price">'+res[i].price+'</a><a class="itemtype">'+res[i].dtype+'</a><a class="item_stock">'+res[i].stockQuantity+'</a><a class="madecomp">'+res[i].manufacturedCompany+'</a><a class="item_madein">'+res[i].madeIn+'</a><a class="item_weight">'+res[i].weight+'</a></span></li>'
+        $("#itemlist").append(html);
+    }
+
+}

--- a/src/main/resources/static/js/view_member.js
+++ b/src/main/resources/static/js/view_member.js
@@ -1,0 +1,24 @@
+$(document).ready(function (){
+    ListSetting();
+})
+
+async function getMembers(offset,limit){
+    const res=await fetch("/api/v1/members/all?offset="+offset+"&limit="+limit).then(response => response.json())
+    return ListPrint(res);
+}
+
+function ListSetting(){
+    getMembers(0,100);
+}
+
+function ListPrint(res){
+
+
+    for(i=0; i<res.length;i++){
+        var html=getLiTag(res[i].member_id,res[i].name,res[i].roleType,res[i].username,res[i].email,res[i].phone_num,res[i].enrollddate)
+        $("#memberlist").append(html);
+    }
+}
+function getLiTag(memberid,name,roletype,id,email,phone_num,enrolldate){
+    return '<li><span><a class="member_id">'+memberid+'</a><a class="name">'+name+'</a> <a class="roleType">'+roletype+'</a> <a class="아이디">'+id+'</a><a class="email">'+email+'</a><a class="phone_num">'+phone_num+'</a><a class="enrolldate">'+enrolldate+'</a></a></span></li>'
+}

--- a/src/main/resources/static/js/view_order.js
+++ b/src/main/resources/static/js/view_order.js
@@ -1,0 +1,20 @@
+
+$(document).ready(function(){
+    ListSetting()
+})
+function ListSetting(){
+    getOrders(0,100);
+}
+async function getOrders(offset,limit){
+    const res=await fetch("/api/v1/orders/all?offset="+offset+"&limit="+limit).then(response => response.json())
+    return ListPrint(res);
+}
+
+function ListPrint(res){
+    alert(res[0].username);
+    for(i=0; 0<res.length;i++){
+        var html='<li><span><a class="order_id">'+res[i].orderId+'</a><a class="username">'+res[i].user_name+'</a><a class="totalprice">'+res[i].totalprice+'</a><a class="orderdate">'+res[i].orderdate+'</a><button class="order_desc">주문 상세보기</button></span></li>'
+        $("#orderlist").append(html);
+    }
+
+}

--- a/src/main/resources/templates/fragments/private/MM_View_Delivery.html
+++ b/src/main/resources/templates/fragments/private/MM_View_Delivery.html
@@ -2,9 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <link rel="stylesheet" href="../../css/view_delivery.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../../js/view_delivery.js"></script>
+    <title>배송 조회</title>
 </head>
 <body>
-
+    <ul id="delivery_list">
+        <li><span><a class="delivery_id">배송 번호</a><a class="order_id">주문번호</a><a class="customer_name">고객 이름</a><a class="orderdate">주문날짜</a><a class="delivery_status">배송 현황</a><a class="delivery_address">배송 주소</a></span></li>
+    </ul>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/private/MM_View_Item.html
+++ b/src/main/resources/templates/fragments/private/MM_View_Item.html
@@ -5,14 +5,17 @@
     <title>아이템 조회</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../../css/register_faq.css">
+    <link rel="stylesheet" href="../../css/view_item.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Do+Hyeon&family=Jua&display=swap" rel="stylesheet">
-    <script src="../../js/view_item.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../../js/view_item.js"></script>
+
 </head>
 <body>
-
+    <ul id="itemlist">
+        <li id="nav"><span><a class="item_id">제품 번호</a><img class="itemimg_src">제품 이미지</img><a class="itemname">제품 이름</a><a class="item_desc">제품 설명</a><a class="item_price">제품 가격</a><a class="itemtype">제품군</a><a class="item_stock">재고 수량</a><a class="madecomp">제조사</a><a class="item_weight">제품 무게</a></span></li>
+    </ul>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/private/MM_View_Members.html
+++ b/src/main/resources/templates/fragments/private/MM_View_Members.html
@@ -2,9 +2,16 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <link rel="stylesheet" href="../../css/view_member.css">
+    <link href="https://fonts.googleapis.com/css2?family=Do+Hyeon&family=Jua&display=swap" rel="stylesheet">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../../js/view_member.js"></script>
+
+    <title>회원 조회</title>
 </head>
 <body>
-
+    <ul id="memberlist">
+        <li><span><a class="member_id">회원번호</a><a class="name">이름</a> <a class="roleType">권한</a> <a class="아이디">ID</a><a class="email">이메일</a><a class="phone_num">전화번호</a><a class="enrolldate">가입날짜</a></a></span></li>
+    </ul>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/private/MM_View_Orders.html
+++ b/src/main/resources/templates/fragments/private/MM_View_Orders.html
@@ -1,8 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
+    <link rel="stylesheet" href="../../css/view_order.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="../../js/view_order.js"></script>
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>주문 조회</title>
+    <ul id="orderlist">
+        <li>
+            <span><a class="order_id">주문번호</a><a class="username">고객 이름</a><a class="totalprice">총 가격</a><a class="orderdate">주문 날짜</a><a class="order_desc">주문 상세보기</a></span>
+        </li>
+    </ul>
 </head>
 <body>
 

--- a/src/main/resources/templates/fragments/private/manager.html
+++ b/src/main/resources/templates/fragments/private/manager.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="../css/manager.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <script src="js/manager.js"></script>
+    <script src="../js/manager.js"></script>
 
 </head>
 <body>
@@ -25,7 +25,7 @@
             <li><a>제품</a>
                 <ul>
                     <li><a onclick="window.open('/admin/manage/register-item','new',toolbar=false,menubar=false,scrollbars=true,width=700,height=900);return false">등록</a></li>
-                    <li><a href="#">조회</a></li>
+                    <li><a href="/admin/manage/view-item">조회</a></li>
                 </ul>
             </li>
             <li><a>FAQ</a>


### PR DESCRIPTION
** 0112 @Test annotation mismatch(jupyter.api x) **
** 0114 BootStrap FrameWork **
** 0115 login page proto // notice board 완성 **
** 0116 회원가입 시퀀스 완성 **
** 0123 메인 홈페이지 디자인 변경 **
** 0125 메인 홈 get method 완료**
** 0126 관리자 페이지 생성 및 업로드 기능 완료 **
** 0128 로그인 시스템 및 관리자 권한 완료 **
** 0128-2 공지사항 등록 및 item 로직 변경(팩토리 메소드 패턴 적용) **

** 0129 파일저장 시스템 변경 및 api 리팩토링 + 이미지 파일 외부로 전환(메인 디렉토리 하위 img)+공지사항 조회기능 추가 및 post url 변경**

**0131 FAQ조회 및 삭제 기능 완성
  제품 조회,주문 관리조회,회원 관리 조회,배송 조회 만들어야함. **

** 0203 jenkins 적용 완료 서버 포트 다시 롤백 -> 8080 **

** 메인페이지 로그인 세션 적용 **

** 관리자 페이지 조회기능 전부 적용 **
해야할 일- 관리자 페이지 꾸미기 및 세부 정보 버튼 설정