### PR TITLE
1.1_5: 메인페이지 변경 및 fetch를 통한 통신 설정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-test'
 	compileOnly group: 'org.thymeleaf.extras', name: 'thymeleaf-extras-springsecurity5', version: '3.0.4.RELEASE'
 	implementation 'org.springframework.session:spring-session-core'
-
+	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 	annotationProcessor 'org.projectlombok:lombok'
 
 }

--- a/src/main/java/com/pipe09/OnlineShop/Configuration/SwaggerConfig.java
+++ b/src/main/java/com/pipe09/OnlineShop/Configuration/SwaggerConfig.java
@@ -1,0 +1,55 @@
+package com.pipe09.OnlineShop.Configuration;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.ParameterBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.ModelRef;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Parameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    private static final String API_NAME="DaeBong Online Shop API";
+    private static final String API_VERSION="1.0.0";
+    private static final String API_DESCRIPTION="Online shop API 명세서";
+
+    @Bean
+    public Docket api(){
+        Parameter parmeterbuilder= new ParameterBuilder().name(HttpHeaders.AUTHORIZATION)
+                .description("Access Token")
+                .modelRef(new ModelRef("string"))
+                .parameterType("header")
+                .required(false)
+                .build();
+        List<Parameter> globalParameters = new ArrayList<>();
+        globalParameters.add(parmeterbuilder);
+
+        return new Docket(DocumentationType.SWAGGER_2)
+                .globalOperationParameters(globalParameters)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.pipe09.OnlineShop.Controller.ApiController"))
+                .paths(PathSelectors.any()).build();
+    }
+
+    public ApiInfo apiInfo(){
+        return new ApiInfoBuilder()
+                .title(API_NAME)
+                .version(API_VERSION)
+                .description(API_DESCRIPTION)
+                .build();
+    }
+
+}

--- a/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/ItemApiController.java
+++ b/src/main/java/com/pipe09/OnlineShop/Controller/ApiController/ItemApiController.java
@@ -4,12 +4,15 @@ package com.pipe09.OnlineShop.Controller.ApiController;
 import com.pipe09.OnlineShop.Domain.Item.Item;
 import com.pipe09.OnlineShop.Dto.ItemDto;
 import com.pipe09.OnlineShop.Dto.M_ItemDto;
+import com.pipe09.OnlineShop.Dto.TestDto;
+import com.pipe09.OnlineShop.GlobalMapper.DefaultMapper;
 import com.pipe09.OnlineShop.Service.ItemService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -21,13 +24,27 @@ public class ItemApiController {
 
     @GetMapping("/api/v1/m-item")
     public List<M_ItemDto> getminiItems(@RequestParam int offset,@RequestParam int limit){
-        List<Item>items=service.findAll(0,100);
+        List<Item>items=service.findAll(offset,limit);
         List<M_ItemDto> dtoList=Item.itemtoDto(items);
         log.info("MiniItemList :" + dtoList.toString());
 
         return dtoList;
 
     }
+
+    @GetMapping("api/v2/item/test")
+    public List<TestDto> getTest(@RequestParam int offset,@RequestParam int limit){
+        List<Item>items=service.findAll(offset,limit);
+        items.stream().forEach(item -> System.out.println(item.getName()));
+        AtomicReference<DefaultMapper<TestDto>> mapper=new AtomicReference<>();
+        List<TestDto>dtoList=items.stream().map(item -> {
+            mapper.set(new DefaultMapper<>(new TestDto()));
+            return mapper.get().Translate(item);
+        }).collect(Collectors.toList());
+        return dtoList;
+    }
+
+
 
     @GetMapping("/api/v1/m-item/{DTYPE}")
     public List<M_ItemDto> getminiItemsbyType(@PathVariable String DTYPE,@RequestParam int offset,@RequestParam int limit){

--- a/src/main/java/com/pipe09/OnlineShop/Domain/Item/Typed/Hammer.java
+++ b/src/main/java/com/pipe09/OnlineShop/Domain/Item/Typed/Hammer.java
@@ -11,6 +11,6 @@ import javax.persistence.*;
 @Getter
 @Setter
 public class Hammer extends Item {
-
+    
 }
 

--- a/src/main/java/com/pipe09/OnlineShop/Domain/Item/Typed/LeakDetector.java
+++ b/src/main/java/com/pipe09/OnlineShop/Domain/Item/Typed/LeakDetector.java
@@ -5,13 +5,21 @@ import com.pipe09.OnlineShop.Domain.Item.Item;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import javax.persistence.*;
 
 @Entity
 @DiscriminatorValue("L")
 @Getter
 @Setter
 public class LeakDetector extends Item {
-
+    private Long Item_ID;
+    private String Name;
+    private int Price;
+    private int StockQuantity;
+    private String Description;
+    private int Weight;
+    private String MadeIn;
+    private String ManufacturedCompany;
+    public String imgSrc;
+    private String DTYPE;
 }

--- a/src/main/java/com/pipe09/OnlineShop/Dto/M_ItemDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/M_ItemDto.java
@@ -2,7 +2,6 @@ package com.pipe09.OnlineShop.Dto;
 
 import com.pipe09.OnlineShop.Domain.Item.Item;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 
 
 @Data

--- a/src/main/java/com/pipe09/OnlineShop/Dto/TestDto.java
+++ b/src/main/java/com/pipe09/OnlineShop/Dto/TestDto.java
@@ -1,0 +1,23 @@
+package com.pipe09.OnlineShop.Dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestDto {
+    private Long Item_ID;
+    private String Name;
+    private int Price;
+    private int StockQuantity;
+    private String Description;
+    private int Weight;
+    private String DTYPE;
+
+    @Override
+    public String toString(){
+        return this.getItem_ID()+this.getPrice()+this.getPrice()+this.getName();
+    }
+}

--- a/src/main/java/com/pipe09/OnlineShop/GlobalMapper/DefaultMapper.java
+++ b/src/main/java/com/pipe09/OnlineShop/GlobalMapper/DefaultMapper.java
@@ -1,0 +1,81 @@
+package com.pipe09.OnlineShop.GlobalMapper;
+
+import com.pipe09.OnlineShop.Domain.Delivery.Delivery;
+import com.pipe09.OnlineShop.Domain.Member.Member;
+import com.pipe09.OnlineShop.Domain.Orders.Orders;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.asm.Advice;
+import ognl.BooleanExpression;
+import springfox.documentation.swagger2.mappers.ModelMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.text.Format;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.partitioningBy;
+
+
+@Slf4j
+public class DefaultMapper<R> implements Mapper{
+    R object;
+    Strategy strategy;
+    HashMap<String, Optional<Object>>mapTable=new HashMap<>();
+
+    public DefaultMapper(R r){
+        this.object=r;
+    }
+
+
+    @Override
+    public R Translate(Object from){
+
+
+        Arrays.stream(object.getClass().getDeclaredFields()).forEach(to -> mapTable.put(to.getName().toLowerCase(),null));
+        Arrays.stream(from.getClass().getDeclaredFields()).forEach(one -> {
+            try{
+                one.setAccessible(true);
+                if(mapTable.containsKey(one.getName().toLowerCase())){
+                    Object value=one.get(from);
+                    Optional inputvalue=Optional.of(value);
+                    mapTable.put(one.getName().toLowerCase(),inputvalue);
+                }
+
+
+            }catch (IllegalAccessException e){
+                log.info(e.toString());
+            }
+
+
+        });
+
+
+        Method[] methods=object.getClass().getMethods();
+        List<Method> Setter=Arrays.stream(methods).filter(method -> method.getName().contains("set")).collect(Collectors.toList());
+            //12+33+1+3 == public void + objectname + . + set
+
+
+        Setter.stream().forEach(setter -> {
+
+            try{
+                setter.setAccessible(true);
+                setter.invoke(object,mapTable.get(setter.getName().substring(3).toLowerCase()).get());
+            }catch (IllegalAccessException | InvocationTargetException e){
+                log.info(e.toString());
+            }
+
+
+
+        });
+
+
+
+        return (R)object;
+    }
+
+}

--- a/src/main/java/com/pipe09/OnlineShop/GlobalMapper/Mapper.java
+++ b/src/main/java/com/pipe09/OnlineShop/GlobalMapper/Mapper.java
@@ -1,0 +1,8 @@
+package com.pipe09.OnlineShop.GlobalMapper;
+
+import java.util.List;
+
+public interface Mapper<R> {
+    public R Translate(R r);
+
+}

--- a/src/main/java/com/pipe09/OnlineShop/GlobalMapper/Strategy.java
+++ b/src/main/java/com/pipe09/OnlineShop/GlobalMapper/Strategy.java
@@ -1,0 +1,4 @@
+package com.pipe09.OnlineShop.GlobalMapper;
+
+public interface Strategy {
+}

--- a/src/main/java/com/pipe09/OnlineShop/InitDb.java
+++ b/src/main/java/com/pipe09/OnlineShop/InitDb.java
@@ -13,7 +13,7 @@ import javax.annotation.PostConstruct;
 @RequiredArgsConstructor
 public class InitDb {
     private final InitSerivce initSerivce;
-    /*
+
     @PostConstruct
     public void init(){
         initSerivce.dbInit();
@@ -21,7 +21,7 @@ public class InitDb {
 
 
     }
-    */
+
 
 
 }

--- a/src/main/java/com/pipe09/OnlineShop/InitSerivce.java
+++ b/src/main/java/com/pipe09/OnlineShop/InitSerivce.java
@@ -1,23 +1,15 @@
 package com.pipe09.OnlineShop;
 
 
-import com.pipe09.OnlineShop.Domain.Delivery.Delivery;
-import com.pipe09.OnlineShop.Domain.Delivery.Deliverystatus;
 import com.pipe09.OnlineShop.Domain.Item.Item;
-import com.pipe09.OnlineShop.Domain.Item.Typed.*;
-import com.pipe09.OnlineShop.Domain.Member.Member;
-import com.pipe09.OnlineShop.Domain.Orders.OrderItem;
-import com.pipe09.OnlineShop.Domain.Orders.Orders;
-import com.pipe09.OnlineShop.Utils.Utils;
+
+import com.pipe09.OnlineShop.Dto.TestDto;
+import com.pipe09.OnlineShop.GlobalMapper.DefaultMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-import java.nio.file.Watchable;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.Date;
 
 // 객체를 test용으로 안에 넣을때 사용하는 클래스
 @Component
@@ -99,8 +91,12 @@ public class InitSerivce {
 
     }
     public void dbInit2(){
-        /*
+        DefaultMapper<TestDto> mapper=new DefaultMapper(new TestDto());
         Item newitem=em.find(Item.class,30L);
+        TestDto dto= mapper.Translate(newitem);
+        System.out.println(dto.toString());
+        /*
+
         Member member=em.find(Member.class,5L);
 
         OrderItem newOrderitem=new OrderItem();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,4 +26,5 @@ server.error.include-stacktrace=always
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
 spring.jackson.serialization.fail-on-empty-beans=false
 server.servlet.session.timeout=3600
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 #logging.level.org.springframework.security=debug


### PR DESCRIPTION
** 0112 @Test annotation mismatch(jupyter.api x) **
** 0114 BootStrap FrameWork **
** 0115 login page proto // notice board 완성 **
** 0116 회원가입 시퀀스 완성 **
** 0123 메인 홈페이지 디자인 변경 **
** 0125 메인 홈 get method 완료**
** 0126 관리자 페이지 생성 및 업로드 기능 완료 **
** 0128 로그인 시스템 및 관리자 권한 완료 **
** 0128-2 공지사항 등록 및 item 로직 변경(팩토리 메소드 패턴 적용) **

** 0129 파일저장 시스템 변경 및 api 리팩토링 + 이미지 파일 외부로 전환(메인 디렉토리 하위 img)+공지사항 조회기능 추가 및 post url 변경**

**0131 FAQ조회 및 삭제 기능 완성
  제품 조회,주문 관리조회,회원 관리 조회,배송 조회 만들어야함. **

** 0203 jenkins 적용 완료 서버 포트 다시 롤백 -> 8080 **

** 메인페이지 로그인 세션 적용 **

** 관리자 페이지 조회기능 전부 적용 **
해야할 일- 관리자 페이지 꾸미기 및 세부 정보 버튼 설정

** 02-15 Dto 자동 변환을 지원하는 Mapper 추가 **
@AtomicReferences 공부할 것